### PR TITLE
Detect static url by scheme=static

### DIFF
--- a/acceptance_tests/url_test.py
+++ b/acceptance_tests/url_test.py
@@ -1,4 +1,6 @@
 import pytest
+from pyramid import testing
+from pyramid.paster import bootstrap
 
 from getitfixed.url import generate_url
 
@@ -9,4 +11,15 @@ def test_generate_url(app_env):
     assert "https://server.com/static/image.png" == generate_url(request, "https://server.com/static/image.png")
     assert "/static/image.png" == generate_url(request, "/static/image.png")
     assert "static/image.png" == generate_url(request, "static/image.png")
-    assert "http://localhost/getitfixed_static/image.png" == generate_url(request, "getitfixed:static/image.png")
+    # Static url with explicit package name
+    assert "http://localhost/getitfixed_static/image.png" == generate_url(request, "static://getitfixed:static/image.png")
+    # Default to registry.package_name
+    assert "http://localhost/getitfixed_static/image.png" == generate_url(request, "static://static/image.png")
+
+def test_gmf_2_5():
+    with bootstrap("tests.ini") as env:
+        # Compatibility with GMF 2.5
+        config = testing.setUp(registry=env["registry"])
+        config.add_static_view(name="static", path="/etc/geomapfish/static")
+        request = env["request"]
+        assert "http://localhost/static/image.png" == generate_url(request, "static:///etc/geomapfish/static/image.png")

--- a/getitfixed/models/getitfixed.py
+++ b/getitfixed/models/getitfixed.py
@@ -318,7 +318,7 @@ class Issue(Base):
             self.category.icon
             if self.category and self.category.icon
             else _getitfixed_config.get(
-                "default_icon", "getitfixed:static/icons/cat-default.png"
+                "default_icon", "static://getitfixed:static/icons/cat-default.png"
             )
         )
         return generate_url(request, icon)

--- a/getitfixed/scripts/initializedb.py
+++ b/getitfixed/scripts/initializedb.py
@@ -100,7 +100,7 @@ def setup_test_data(dbsession):
                     label_en="Category «{}»".format(i),
                     label_fr="Catégorie «{}»".format(i),
                     email="test{}@toto.com".format(i),
-                    icon="getitfixed:static/icons/{}".format(ICONS[i % 3])
+                    icon="static://getitfixed:static/icons/{}".format(ICONS[i % 3])
                     if i != 3
                     else None,
                 )

--- a/getitfixed/url.py
+++ b/getitfixed/url.py
@@ -4,14 +4,9 @@ from urllib.parse import urlparse
 def generate_url(request, url_definition):
     o = urlparse(url_definition)
 
-    if o.scheme != "" and o.netloc != "":
-        # Definition is an absolute url ex: https://server.com/static/image.png
-        return url_definition
+    if o.scheme == "static":
+        # Definition is a static path ex: static://getitfixed:static/image.png
+        return request.static_url("{}{}".format(o.netloc, o.path))
 
-    if o.scheme == "" and o.netloc == "":
-        # Definition is a relative url ex: static/image.png or /static/image.png
-        return url_definition
-
-    if o.scheme != "" and o.netloc == "":
-        # Definition is a static path ex: getitfixed:static/image.png
-        return request.static_url(url_definition)
+    # Definition is an absolute url ex: https://server.com/static/image.png
+    return url_definition

--- a/vars.yaml
+++ b/vars.yaml
@@ -5,7 +5,7 @@ vars:
       host: smtp
 
    getitfixed:
-      default_icon: "getitfixed:static/icons/cat-default.png"
+      default_icon: "static://getitfixed:static/icons/cat-default.png"
       map:
         srid: 21781
         projections:


### PR DESCRIPTION
As in GMF static files are not in a python package but in /etc/geomapfish/static,
we need a way to define such static urls, ex:
static:///etc/geomapfish/static/...