### PR TITLE
Add issue.private field

### DIFF
--- a/acceptance_tests/admin/issue_test.py
+++ b/acceptance_tests/admin/issue_test.py
@@ -99,6 +99,28 @@ class TestAdminIssueViews(AbstractViewsTests):
         assert 0 == len(json["rows"])
         assert 0 == json["total"]
 
+    def test_set_private(self, test_app, issue_test_data):
+        issue = issue_test_data["issues"][0]
+        issue.private = False
+        resp = test_app.post("/getitfixed_admin/issues/{}/set_private".format(issue.hash), status=200)
+        assert resp.json["success"]
+        assert (
+            "http://localhost/getitfixed_admin/issues/{}?msg_col=submit_ok".format(issue.hash)
+            == resp.json["redirect"]
+        )
+        assert issue.private
+
+    def test_set_public(self, test_app, issue_test_data):
+        issue = issue_test_data["issues"][0]
+        issue.public = False
+        resp = test_app.post("/getitfixed_admin/issues/{}/set_public".format(issue.hash), status=200)
+        assert resp.json["success"]
+        assert (
+            "http://localhost/getitfixed_admin/issues/{}?msg_col=submit_ok".format(issue.hash)
+            == resp.json["redirect"]
+        )
+        assert not issue.private
+
     @patch("getitfixed.views.admin.events.send_email")
     def test_edit_then_post_comment(
         self, send_email, test_app, issue_test_data, dbsession

--- a/acceptance_tests/public/issue_test.py
+++ b/acceptance_tests/public/issue_test.py
@@ -153,7 +153,6 @@ class TestIssueViews(AbstractViewsTests):
         )
 
     def test_open(self, dbsession, test_app, issue_test_data):
-
         issue = dbsession.query(Issue).first()
         resp = test_app.get("/getitfixed/issues/{}".format(issue.id), status=200)
         self._check_mapping(
@@ -163,3 +162,9 @@ class TestIssueViews(AbstractViewsTests):
                 {"name": "localisation", "value": issue.localisation, "readonly": True},
             ],
         )
+
+    def test_open_private(self, dbsession, test_app, issue_test_data):
+        issue = issue_test_data["issues"][0]
+        issue.private = True
+        dbsession.flush()
+        test_app.get("/getitfixed/issues/{}".format(issue.id), status=404)

--- a/getitfixed/alembic/versions/6d8c64186efa_add_field_issue_private.py
+++ b/getitfixed/alembic/versions/6d8c64186efa_add_field_issue_private.py
@@ -1,0 +1,29 @@
+"""Add field issue.private
+
+Revision ID: 6d8c64186efa
+Revises: f12edd1058e7
+Create Date: 2020-06-04 07:47:52.848957
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "6d8c64186efa"
+down_revision = "f12edd1058e7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "issue",
+        sa.Column(
+            "private", sa.Boolean(), nullable=False, server_default=sa.text("False")
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("issue", "private")

--- a/getitfixed/models/getitfixed.py
+++ b/getitfixed/models/getitfixed.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     ForeignKey,
     String,
     Text,
+    text,
 )
 from sqlalchemy.orm import backref, relationship
 from sqlalchemy.sql.expression import func
@@ -327,6 +328,12 @@ class Issue(Base):
                 ),
             }
         },
+    )
+    private = Column(
+        Boolean,
+        nullable=False,
+        server_default=text("False"),
+        info={"colanderalchemy": {"title": _("Private"), "exclude": True}},
     )
     events = relationship(
         "Event",

--- a/getitfixed/routes.py
+++ b/getitfixed/routes.py
@@ -20,3 +20,13 @@ def includeme(config):
     config.add_c2cgeoform_application(
         "getitfixed_admin", [("issues", Issue), ("event", Event)]
     )
+    config.add_route(
+        "getitfixed_set_private",
+        "/{application:getitfixed_admin}/{table:issues}/{id}/set_private",
+        pregenerator=pregenerator,
+    )
+    config.add_route(
+        "getitfixed_set_public",
+        "/{application:getitfixed_admin}/{table:issues}/{id}/set_public",
+        pregenerator=pregenerator,
+    )

--- a/getitfixed/views/public/issues.py
+++ b/getitfixed/views/public/issues.py
@@ -99,6 +99,7 @@ class IssueViews(AbstractViews):
             ._base_query()
             .outerjoin(Issue.type)
             .filter(Issue.status.notin_([STATUS_NEW]))
+            .filter(Issue.private.is_(False))
             .options(subqueryload(Issue.type))
         )
 
@@ -119,8 +120,11 @@ class IssueViews(AbstractViews):
     def _grid_item_actions(self, item):
         return {"dropdown": []}
 
-    def _item_actions(self, item):
-        return []
+    def _get_object(self):
+        obj = super()._get_object()
+        if obj.private:
+            raise HTTPNotFound()
+        return obj
 
     @view_config(
         route_name="c2cgeoform_item",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 alembic
 c2c.template
-c2cgeoform>=2.1.13
+c2cgeoform>=2.1.14
 beaker_redis
 plaster_pastedeploy
 psycopg2-binary


### PR DESCRIPTION
Add boolean field `issue.private`.
Add buttons in admin form (readonly) to put the issue in public/private mode.
Return 404 in public interface for private issues.

Based on #48 (only last commit is related with this PR)
Needs https://github.com/camptocamp/c2cgeoform/pull/220