### PR TITLE
Relax Python and alembic floors for c2cgeoportal 2.9 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-alembic>=1.18.4
+alembic>=1.13.3
 c2c.template>=2.4.2
 pyyaml-include>=2.2
 c2cgeoform>=2.5.1

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,11 @@ setup(
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Framework :: Pyramid",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
@@ -31,7 +35,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     test_suite="getitfixed",
-    python_requires=">=3.12",
+    python_requires=">=3.10",
     install_requires=REQUIRES,
     entry_points="""\
         [paste.app_factory]


### PR DESCRIPTION
Lower python_requires from ">=3.12" to ">=3.10" and add explicit classifiers for 3.10 through 3.14. No 3.12-only syntax is used in the codebase; the previous 3.12 bump was metadata-only.

Lower the alembic floor from >=1.18.4 to >=1.13.3 to match c2cgeoportal 2.9's pin. Migration scripts only use the stable `op` and `context` API surface.